### PR TITLE
Fixed Leave Syllabus

### DIFF
--- a/app/Http/Controllers/SyllabusUserController.php
+++ b/app/Http/Controllers/SyllabusUserController.php
@@ -268,7 +268,8 @@ class SyllabusUserController extends Controller
             $request->session()->flash('error', 'Failed to leave the syllabus');
         }
 
-        return redirect()->back();
+        // return to the dashboard
+        return redirect()->route('home');
     }
 
     public function transferOwnership(Request $request)


### PR DESCRIPTION
Was redirecting->back which just led to index being called with a SyllabusID and UserID that were unnassociated, so it threw an error when searching for them. Now it redirects to dashboard manually.