### PR TITLE
Fixed BC Degree Standards Bug + Course # Bug

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -563,7 +563,11 @@ class CourseController extends Controller
             $standardOutcomeMap = [];
             foreach ($courseStandardOutcomes as $standardOutcome) {
                 if (StandardsOutcomeMap::where('standard_id', $standardOutcome->standard_id)->where('course_id', $course->course_id)->exists()) {
-                    $standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::find(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]))->first();
+                                //dd(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]));
+                                $standardScale=StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]);
+                                //dd($standardScale->standard_scale_id);
+                                $standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::where('standard_scale_id',$standardScale->standard_scale_id)->first();
+                                //$standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::find(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]))->first();
                 }
             }
 

--- a/app/Http/Controllers/CourseWizardController.php
+++ b/app/Http/Controllers/CourseWizardController.php
@@ -571,7 +571,11 @@ class CourseWizardController extends Controller
         $standardOutcomeMap = [];
         foreach ($courseStandardOutcomes as $standardOutcome) {
             if (StandardsOutcomeMap::where('standard_id', $standardOutcome->standard_id)->where('course_id', $course->course_id)->exists()) {
-                $standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::find(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]))->first();
+                //dd(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]));
+                $standardScale=StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]);
+                //dd($standardScale->standard_scale_id);
+                $standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::where('standard_scale_id',$standardScale->standard_scale_id)->first();
+                //$standardOutcomeMap[$standardOutcome->standard_id][$course->course_id] = StandardScale::find(StandardsOutcomeMap::firstWhere([['standard_id', $standardOutcome->standard_id], ['course_id', $course->course_id]]))->first();
             }
         }
 

--- a/app/Http/Controllers/ProgramController.php
+++ b/app/Http/Controllers/ProgramController.php
@@ -234,6 +234,7 @@ class ProgramController extends Controller
         $coursesByLevels['Other'] = collect();
 
         foreach ($program->courses as $course) {
+            if($course->course_num!=NULL){
             switch ($course->course_num[0]) {
                 case 1:
                     $coursesByLevels['100 Level']->push($course);
@@ -256,6 +257,7 @@ class ProgramController extends Controller
                 default:
                     $coursesByLevels['Other']->push($course);
             }
+        } else $coursesByLevels['Other']->push($course);
         }
 
         return $coursesByLevels;


### PR DESCRIPTION
BC Degree Standards charts were broken at course level because the syntax used to retrieve the Standard Outcome Maps changed during the Laravel update. I also corrected a bug in the Program Overview which was caused by courses not having a course number, I just added an if statement and an extra case.